### PR TITLE
Fix autotick

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
-{% set component_name = "common" %}
-{% set repo_name = "gz-" + component_name %}
-{% set version = "5.3.1" %}
-{% set major_version = version.split('.')[0] %}
+{% set repo_name = "gz-common" %}
+{% set component_name = repo_name.split('-')[1] %}
+{% set version = "5_5.3.1" %}
+{% set version_package = version.split('_')[1] %}
+{% set major_version = version.split('_')[0] %}
 {% set name = repo_name + major_version %}
 {% set component_version = component_name + major_version %}
 {% set cxx_name = "lib" + name %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_package }}
 
 source:
-  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
+  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
     sha256: dbb7eb6639fec27bb971d0df6a0d17d8076e82a7a7f3cadb570adab02ab7d9ad
     patches:
       - librt_linkage.patch  # [linux]


### PR DESCRIPTION

Hopefully fix https://github.com/conda-forge/gz-common-feedstock/issues/10, w.r.t. to https://github.com/conda-forge/gz-sim-feedstock/issues/11 I try to continue to use `{{ repo_name }}` in the url, but `{{ repo_name }}` is assigned to a literal string instead of being the result of the concatenation of different strings.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
