### PR TITLE
Add check if the io compoment of gz-common is built

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,8 @@ outputs:
         - test -f ${PREFIX}/lib/lib{{ name }}-graphics.dylib  # [osx]
         - test -f ${PREFIX}/lib/lib{{ name }}-av.so  # [linux]
         - test -f ${PREFIX}/lib/lib{{ name }}-av.dylib  # [osx]
+        - test -f ${PREFIX}/lib/lib{{ name }}-io.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}-io.dylib  # [osx]
         - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
         - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
@@ -65,6 +67,8 @@ outputs:
         - if not exist %PREFIX%\\Library\\bin\\{{ name }}-graphics.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\{{ name }}-av.lib exit 1  # [win]
         - if not exist %PREFIX%\\Library\\bin\\{{ name }}-av.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}-io.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}-io.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
 
   - name: {{ name }}


### PR DESCRIPTION
Required by https://github.com/conda-forge/gz-sim-feedstock/pull/13#issuecomment-1418081410 .
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
