### PR TITLE
[v5] Use libgdal-core instead of all GDAL plugins

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -22,7 +22,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 libuuid:
 - '2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -22,7 +22,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 libuuid:
 - '2'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -22,7 +22,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 libuuid:
 - '2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,7 +24,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,7 +24,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,7 +14,7 @@ ffmpeg:
 - '9'
 glib:
 - '2'
-libgdal:
+libgdal_core:
 - '3.13'
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About gz-common-feedstock
 =========================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gz-common-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gz-common-feedstock/blob/v5/LICENSE.txt)
 
 Home: https://github.com/gazebosim/gz-common
 
@@ -23,7 +23,7 @@ Current build status
     <td>GitHub Actions</td>
     <td>
       <a href="https://github.com/conda-forge/gz-common-feedstock/actions/workflows/conda-build.yml">
-        <img src="https://github.com/conda-forge/gz-common-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+        <img src="https://github.com/conda-forge/gz-common-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=v5">
       </a>
     </td>
   </tr>
@@ -33,8 +33,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17565&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-common-feedstock?branchName=main">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17565&branchName=v5">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-common-feedstock?branchName=v5">
           </a>
         </summary>
         <table>
@@ -42,8 +42,8 @@ Current build status
           <tbody><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17565&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-common-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=17565&branchName=v5">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gz-common-feedstock?branchName=v5&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -8,7 +8,7 @@ conda_build_tool: rattler-build
 conda_forge_output_validation: true
 conda_install_tool: pixi
 github:
-  branch_name: main
+  branch_name: v5
   tooling_branch_name: main
 provider:
   linux_aarch64: default

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -65,6 +65,8 @@ outputs:
         - libgdal-core
         - libgdal-netcdf
         - assimp
+      run:
+        - libgdal-netcdf
       run_exports:
         - ${{ pin_subpackage(cxx_name, upper_bound='x') }}
     tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,7 +25,7 @@ source:
       - 660.patch
 
 build:
-  number: 9
+  number: 10
 
 outputs:
   - package:
@@ -59,7 +59,9 @@ outputs:
         - tinyxml2
         - glib
         - ffmpeg
-        - libgdal
+        # Only the core GDAL library is needed; the libgdal metapackage pulls
+        # every optional plugin, including TileDB and its unrelated cloud ABI.
+        - libgdal-core
         - assimp
       run_exports:
         - ${{ pin_subpackage(cxx_name, upper_bound='x') }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -59,9 +59,11 @@ outputs:
         - tinyxml2
         - glib
         - ffmpeg
-        # Only the core GDAL library is needed; the libgdal metapackage pulls
-        # every optional plugin, including TileDB and its unrelated cloud ABI.
+        # Avoid the libgdal metapackage, which pulls every optional plugin,
+        # including TileDB and its unrelated cloud ABI. The netCDF plugin is
+        # needed by gz-common's DEM support and tests.
         - libgdal-core
+        - libgdal-netcdf
         - assimp
       run_exports:
         - ${{ pin_subpackage(cxx_name, upper_bound='x') }}


### PR DESCRIPTION
`gz-common` links to the GDAL core library but does not need every optional GDAL plugin at runtime. Depending on the `libgdal` metapackage pulls all plugins, notably `libgdal-tiledb`, TileDB, the AWS SDK, and Google Cloud libraries.

That unnecessary dependency chain currently also makes the Windows package unsatisfiable during the Protobuf 7 / HDF5 2 / AWS C migrations: HDF5 2 needs `aws-c-common 0.14.3`, while the published TileDB/AWS SDK chain still needs 0.14.2 and/or Protobuf 6.

Using `libgdal-core` provides the headers and linked GDAL library while avoiding unrelated optional plugins. This follows conda-forge's split GDAL packaging model and significantly reduces the runtime dependency surface.

Downstream failure: RoboStack/ros-jazzy#263
