### PR TITLE
[v7] Use libgdal-core instead of all GDAL plugins

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,7 +20,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -20,7 +20,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -20,7 +20,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '21'
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '21'
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,7 +12,7 @@ cxx_compiler:
 - vs2022
 ffmpeg:
 - '9'
-libgdal:
+libgdal_core:
 - '3.13'
 libgz_cmake:
 - '5'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -56,8 +56,14 @@ outputs:
         - freeimage
         - tinyxml2
         - ffmpeg
-        - libgdal
+        # Avoid the libgdal metapackage, which pulls every optional plugin,
+        # including TileDB and its unrelated cloud ABI. The netCDF plugin is
+        # needed by gz-common's DEM support and tests.
+        - libgdal-core
+        - libgdal-netcdf
         - assimp
+      run:
+        - libgdal-netcdf
       run_exports:
         - ${{ pin_subpackage(cxx_name, upper_bound='x') }}
     tests:


### PR DESCRIPTION
See https://github.com/conda-forge/gz-common-feedstock/pull/96 for a rationale of this change.

This should reduce incompatibilities such as https://github.com/RoboStack/ros-rolling/pull/31#issuecomment-5381316934 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
